### PR TITLE
Do not delete kernel image from rootfs.

### DIFF
--- a/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -1,4 +1,0 @@
-do_install_append() {
-    # Delete unused kernel image in rootfs (under /boot/)
-    rm -rf ${D}/boot/${KERNEL_IMAGETYPE}-${KERNEL_VERSION} || true;
-}


### PR DESCRIPTION
This append causes the kernel-image-uimage recipe to be empty. Some
images may want to keep the kernel image in boot, for example if they
want u-boot to load the kernel from the rootfs instead of a fat32 boot
partition. The deletion can be added as a postprocess command in the
image recipes that want it instead.