### PR TITLE
u-boot-variscite: backport patch fixing native tools build

### DIFF
--- a/recipes-bsp/u-boot/u-boot-common.inc
+++ b/recipes-bsp/u-boot/u-boot-common.inc
@@ -5,7 +5,9 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 SRCBRANCH = "imx_v2017.03_4.9.11_1.0.0_ga_var01"
 UBOOT_SRC = "git://github.com/varigit/uboot-imx.git;protocol=git"
-SRC_URI = "${UBOOT_SRC};branch=${SRCBRANCH}"
+SRC_URI = "${UBOOT_SRC};branch=${SRCBRANCH} \
+           file://0001-tools-allow-to-override-python.patch \
+           "
 SRCREV = "e68eee26d6e0877fedbf670c362d5c94d961dede"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/u-boot/u-boot-variscite/0001-tools-allow-to-override-python.patch
+++ b/recipes-bsp/u-boot/u-boot-variscite/0001-tools-allow-to-override-python.patch
@@ -1,0 +1,43 @@
+From 403f30409583787c3fde3e9defc0262f065b9c2e Mon Sep 17 00:00:00 2001
+From: Stefano Babic <sbabic@denx.de>
+Date: Wed, 5 Apr 2017 17:46:41 +0200
+Subject: [PATCH] tools: allow to override python
+
+Not force to use python from PATH. Issue was noted when building with
+Yocto, because python from the distro is always taken instead of
+python-native built during Yocto process.
+
+Signed-off-by: Stefano Babic <sbabic@denx.de>
+CC: Simon Glass <sjg@chromium.org>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+---
+ Makefile       | 2 +-
+ tools/Makefile | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 0692a21..5349339 100644
+--- a/Makefile
++++ b/Makefile
+@@ -348,7 +348,7 @@ OBJCOPY		= $(CROSS_COMPILE)objcopy
+ OBJDUMP		= $(CROSS_COMPILE)objdump
+ AWK		= awk
+ PERL		= perl
+-PYTHON		= python
++PYTHON		?= python
+ DTC		= dtc
+ CHECK		= sparse
+ 
+diff --git a/tools/Makefile b/tools/Makefile
+index 5a7fcbd..3210a71 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -120,7 +120,7 @@ _libfdt.so-sharedobjs += $(LIBFDT_OBJS)
+ libfdt:
+ 
+ tools/_libfdt.so: $(patsubst %.o,%.c,$(LIBFDT_OBJS)) tools/libfdt_wrap.c
+-	LDFLAGS="$(HOSTLDFLAGS)" python $(srctree)/lib/libfdt/setup.py \
++	LDFLAGS="$(HOSTLDFLAGS)" ${PYTHON} $(srctree)/lib/libfdt/setup.py \
+ 		"$(_hostc_flags)" $^
+ 	mv _libfdt.so $@
+ 


### PR DESCRIPTION
Upstream commit b48bfc74ee410b1e6681c620633ffef32aafaba0 solves the below error
reported while building native tools (libfdt) that has been tracked [1] on some
build host configurations.

| unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
| error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

[1] https://github.com/varigit/meta-variscite-fslc/issues/13

Here we backport the above patch after trivial conflict resolution.