### PR TITLE
bcm43xx-utils: fix typo in variscite-wifi.service

### DIFF
--- a/recipes-connectivity/bcm43xx-utils/bcm43xx-utils/variscite-wifi.service
+++ b/recipes-connectivity/bcm43xx-utils/bcm43xx-utils/variscite-wifi.service
@@ -8,4 +8,4 @@ Type=forking
 ExecStart=/etc/wifi/variscite-wifi
 
 [Install]
-WantedBy=muti-user.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>