### PR TITLE
[dunfell] recipes: update github SRC_URIs

### DIFF
--- a/recipes-bsp/freertos-variscite/freertos-variscite_2.10.x.bb
+++ b/recipes-bsp/freertos-variscite/freertos-variscite_2.10.x.bb
@@ -7,7 +7,7 @@ SRCREV = "db2c47b339ab5ccaa923d4bc3de3a5222439fc15"
 CM_GCC = "gcc-arm-none-eabi-10-2020-q4-major"
 
 SRC_URI += " \
-    git://github.com/varigit/freertos-variscite.git;protocol=git;branch=${MCUXPRESSO_BRANCH}; \
+    git://github.com/varigit/freertos-variscite.git;protocol=https;branch=${MCUXPRESSO_BRANCH}; \
     https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2;name=gcc-arm-none-eabi-10-2020-q4-major \
 "
 

--- a/recipes-bsp/freertos-variscite/freertos-variscite_2.8.x.bb
+++ b/recipes-bsp/freertos-variscite/freertos-variscite_2.8.x.bb
@@ -7,7 +7,7 @@ SRCREV = "fa71caba163f20b950506807fbc6ea43277fd2cb"
 CM_GCC = "gcc-arm-none-eabi-9-2019-q4-major"
 
 SRC_URI += " \
-    git://github.com/varigit/freertos-variscite.git;protocol=git;branch=${MCUXPRESSO_BRANCH}; \
+    git://github.com/varigit/freertos-variscite.git;protocol=https;branch=${MCUXPRESSO_BRANCH}; \
     https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2;name=gcc-arm-none-eabi-9-2019-q4-major \
 "
 

--- a/recipes-bsp/freertos-variscite/freertos-variscite_2.9.x.bb
+++ b/recipes-bsp/freertos-variscite/freertos-variscite_2.9.x.bb
@@ -7,7 +7,7 @@ SRCREV = "47de77edd34f7a716bbb3ac4a34e0e6cf1145509"
 CM_GCC = "gcc-arm-none-eabi-9-2020-q2-update"
 
 SRC_URI += " \
-    git://github.com/varigit/freertos-variscite.git;protocol=git;branch=${MCUXPRESSO_BRANCH}; \
+    git://github.com/varigit/freertos-variscite.git;protocol=https;branch=${MCUXPRESSO_BRANCH}; \
     https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2;name=gcc-arm-none-eabi-9-2020-q2-update \
 "
 

--- a/recipes-bsp/imx-atf/imx-atf_2.2.bbappend
+++ b/recipes-bsp/imx-atf/imx-atf_2.2.bbappend
@@ -1,3 +1,3 @@
-SRC_URI = "git://github.com/varigit/imx-atf;protocol=git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/varigit/imx-atf;protocol=https;branch=${SRCBRANCH}"
 SRCBRANCH = "imx_5.4.24_2.1.0_var01"
 SRCREV = "7575633e03ff952a18c0a2c0aa543dee793fda5f"

--- a/recipes-bsp/imx-sc-firmware/imx-sc-firmware_%.bbappend
+++ b/recipes-bsp/imx-sc-firmware/imx-sc-firmware_%.bbappend
@@ -12,7 +12,7 @@ SCFW_BRANCH = "1.5.1"
 SRCREV = "495e846a5e1ff5d4208c2fb6529397d80c40ebf7"
 
 SRC_URI += " \
-    git://github.com/varigit/imx-sc-firmware.git;protocol=git;branch=${SCFW_BRANCH}; \
+    git://github.com/varigit/imx-sc-firmware.git;protocol=https;branch=${SCFW_BRANCH}; \
     https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2;name=gcc-arm-none-eabi \
 "
 

--- a/recipes-bsp/u-boot/u-boot-common.inc
+++ b/recipes-bsp/u-boot/u-boot-common.inc
@@ -3,7 +3,7 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 DEPENDS += "bison-native"
 
-UBOOT_SRC ?= "git://github.com/varigit/uboot-imx;protocol=git"
+UBOOT_SRC ?= "git://github.com/varigit/uboot-imx;protocol=https"
 
 SRCBRANCH = "imx_v2020.04_5.4.24_2.1.0_var02"
 SRCREV = "f7d8fa4a77e31a591c80f82b52abb397eabdbd6a"

--- a/recipes-connectivity/wl18xx-calibrator/wl18xx-calibrator_8.7.3.bb
+++ b/recipes-connectivity/wl18xx-calibrator/wl18xx-calibrator_8.7.3.bb
@@ -6,7 +6,7 @@ DEPENDS = "libnl"
 
 #Tag: R8.7_SP3 (8.7.3)
 SRCREV = "5048b59a444ac59ba7171d6e122d5a84581aebf2"
-SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git \
+SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git;branch=master \
            file://0001-plt.h-Do-not-define-EFUSE_PARAMETER_TYPE_ENMT-type-e.patch \  
           "
 

--- a/recipes-connectivity/wlconf/wlconf_8.7.3.bb
+++ b/recipes-connectivity/wlconf/wlconf_8.7.3.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://README;beginline=1;endline=21;md5=adc05a1903d3f107f85
 
 # Tag: R8.7_SP3 (8.7.3)
 SRCREV = "5048b59a444ac59ba7171d6e122d5a84581aebf2"
-SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git"
+SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git;branch=master"
 
 S = "${WORKDIR}/git/wlconf"
 

--- a/recipes-kernel/linux/linux-common.inc
+++ b/recipes-kernel/linux/linux-common.inc
@@ -1,4 +1,4 @@
 LINUX_VERSION = "5.4.142"
 SRCBRANCH = "5.4-2.1.x-imx_var01"
 SRCREV = "3a3815894c59f7624cadceeac3a03c7dcf3a5358"
-KERNEL_SRC = "git://github.com/varigit/linux-imx;protocol=git"
+KERNEL_SRC = "git://github.com/varigit/linux-imx;protocol=https"


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/

GitHub is deprecating unauthenticated protocols, including git:// so update
SRC_URIs with protocol=https

Explicitly pass branch=master where omitted, as bitbake now requires it.

Signed-off-by: Denys Dmytriyenko <denys@konsulko.com>