### PR TITLE
Add check for existing "build_wayland" directory.

### DIFF
--- a/scripts/var_mk_yocto_sdcard/var-create-yocto-sdcard.sh
+++ b/scripts/var_mk_yocto_sdcard/var-create-yocto-sdcard.sh
@@ -21,8 +21,13 @@ else
 	readonly BSP_TYPE="YOCTO"
 	if [[ $MACHINE = "imx6ul-var-dart" || $MACHINE = "imx7-var-som" ]]; then
 		readonly YOCTO_BUILD=${YOCTO_ROOT}/build_x11
-	else
+	elif [[ -d "${YOCTO_ROOT}/build_xwayland" ]]; then
 		readonly YOCTO_BUILD=${YOCTO_ROOT}/build_xwayland
+	elif [[ -d "${YOCTO_ROOT}/build_wayland" ]]; then
+		readonly YOCTO_BUILD=${YOCTO_ROOT}/build_wayland
+	else
+		echo "Unable to find directory to set YOCTO_BUILD to, exiting"
+		exit 1
 	fi
 	readonly YOCTO_DEFAULT_IMAGE=fsl-image-gui
 fi


### PR DESCRIPTION
The [documentation mentions](https://variwiki.com/index.php?title=Yocto_Build_Release&release=RELEASE_HARDKNOTT_V1.3_DART-MX8M-MINI#Supported_distros) that the non-X Wayland is a supported distro. As such, a user may assume to use the directory name `build_wayland` rather than `build_xwayland`, like it is used in the [create bootable SD card](https://variwiki.com/index.php?title=Yocto_Build_Release&release=RELEASE_HARDKNOTT_V1.3_DART-MX8M-MINI#Yocto_pre-built_bootable_SD_card) section. If the user had used `build_wayland`, the script will fail to find the build directory and fail when it attempts to write the image to the card.

This patch adds a check looking first for an existing `build_xwayland` directory, then falling back to `build_wayland` if it doesn't exist. If none exist, instead an error is emitted and the script exits, so the user better knows where the error came from.