### PR TITLE
bcm43xx-utils: Fix i2c-tools dependency for Variscite DART-6UL (for hardknott)

### DIFF
--- a/recipes-connectivity/bcm43xx-utils/bcm43xx-utils.bb
+++ b/recipes-connectivity/bcm43xx-utils/bcm43xx-utils.bb
@@ -19,6 +19,7 @@ FILES_${PN} = " \
 			'${sysconfdir}/init.d ${sysconfdir}/rcS.d ${sysconfdir}/rc2.d ${sysconfdir}/rc3.d ${sysconfdir}/rc4.d ${sysconfdir}/rc5.d', d)} \
 "
 
+RDEPENDS_${PN}_imx6ul-var-dart = "i2c-tools"
 RDEPENDS_${PN}_imx8mq-var-dart = "i2c-tools"
 RDEPENDS_${PN}_imx8mm-var-dart = "i2c-tools"
 RDEPENDS_${PN}_imx8mn-var-som = "i2c-tools"


### PR DESCRIPTION
Variscite DART-6UL WIFI scripts require i2cget to check WIFI
availability. Add dependency on i2c-tools for this board.

Signed-off-by: Florin Sarbu <florin@balena.io>