### PR TITLE
fix error `Conflict package config 'no_gui' set in PACKAGECONFIG` on DISTRO=fsl-framebuffer

### DIFF
--- a/recipes-extended/wxwidgets/wxwidgets_3.2.0.bbappend
+++ b/recipes-extended/wxwidgets/wxwidgets_3.2.0.bbappend
@@ -1,2 +1,4 @@
-PACKAGECONFIG_append = " gstreamer webkit"
-
+PACKAGECONFIG_append = " \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', d.getVar('GTK3DISTROFEATURES'), 'gstreamer', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', d.getVar('GTK3DISTROFEATURES'), 'webkit', '', d)} \
+"


### PR DESCRIPTION
merge https://github.com/varigit/meta-variscite-sdk/pull/1 to dunfell.
(tweaked the commit for dunfell at `PACKAGECONFIG_append` because of the differece between kirkstone and dunfell)

```
Parsing recipes...ERROR: .../meta-variscite-fslc/recipes-extended/wxwidgets/wxwidgets_3.2.0.bb: wxwidgets: PACKAGECONFIG[gstreamer] Conflict package config 'no_gui' set in PACKAGECONFIG.
ERROR: Failed to parse recipe: .../meta-variscite-fslc/recipes-extended/wxwidgets/wxwidgets_3.2.0.bb
```

