### PR TITLE
googletest_git.bbappend: fix error because of default branch change from master to main

### DIFF
--- a/recipes-test/googletest/googletest_git.bbappend
+++ b/recipes-test/googletest/googletest_git.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/google/googletest.git;protocol=https;branch=v1.10.x"


### PR DESCRIPTION
googletest_git.bbappend: fix error because of default branch change from master to main

See https://github.com/google/googletest/issues/4626