### PR TITLE
bmap-tools_3.5.bbappend: fix error because of default branch change from master to main

### DIFF
--- a/recipes-support/bmap-tools/bmap-tools_3.5.bbappend
+++ b/recipes-support/bmap-tools/bmap-tools_3.5.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/intel/${BPN};protocol=https;branch=main"


### PR DESCRIPTION
bmap-tools_3.5.bbappend: fix error because of default branch change from master to main

The default branch of https://github.com/intel/bmap-tools has changed to main.